### PR TITLE
Add key-value typing for compatibility with reactstrap.

### DIFF
--- a/src/cssModuleToInterface.js
+++ b/src/cssModuleToInterface.js
@@ -94,7 +94,7 @@ export const generateGenericExportInterface = (cssModuleKeys, filename, indent) 
 ${interfaceProperties}
 }
 
-export const locals: ${interfaceName};
+export const locals: ${interfaceName} & { [className: string]: string };
 export default locals;
 `);
 };

--- a/test/example-camelcase.css.d.ts
+++ b/test/example-camelcase.css.d.ts
@@ -4,4 +4,5 @@ export interface IExampleCamelcaseCss {
   'barBaz': string;
 }
 
-export const locals: IExampleCamelcaseCss;
+export const locals: IExampleCamelcaseCss & { [className: string]: string };
+export default locals;

--- a/test/expected-example-camelcase.css.d.ts
+++ b/test/expected-example-camelcase.css.d.ts
@@ -4,4 +4,5 @@ export interface IExampleCamelcaseCss {
   'barBaz': string;
 }
 
-export const locals: IExampleCamelcaseCss;
+export const locals: IExampleCamelcaseCss & { [className: string]: string };
+export default locals;

--- a/test/expected-example.css.d.ts
+++ b/test/expected-example.css.d.ts
@@ -3,4 +3,5 @@ export interface IExampleCss {
   'bar-baz': string;
 }
 
-export const locals: IExampleCss;
+export const locals: IExampleCss & { [className: string]: string };
+export default locals;


### PR DESCRIPTION
Some libraries takes `[classname: string]: string` and use `classname` if the mapping is not found. See reactstrap typing and reactstrap.